### PR TITLE
Equivalence correction

### DIFF
--- a/SIMS/inventory/models.py
+++ b/SIMS/inventory/models.py
@@ -181,7 +181,7 @@ class Piece(models.Model):
 
 # Used to create groups of Pieces that will be equivalent between them
 class Equivalence(models.Model):
-    name = models.CharField(max_length=120, null=True, blank=True)
+    name = models.CharField(max_length=120, null=False, blank=False)
     pieceeq_1 = models.ForeignKey(Piece, on_delete=models.CASCADE, related_name='pieceeq_1', null=True, blank=True)
     pieceeq_2 = models.ForeignKey(Piece, on_delete=models.CASCADE, related_name='pieceeq_2',  null=True, blank=True)
     pieceeq_3 = models.ForeignKey(Piece, on_delete=models.CASCADE, related_name='pieceeq_3',  null=True, blank=True)

--- a/SIMS/inventory/views.py
+++ b/SIMS/inventory/views.py
@@ -475,17 +475,27 @@ def show_piece(request, primary_key):
     instance_discarded = PieceInstance.objects.filter(status='Discarded', piece=piece).count()
     instance_in_reparation = PieceInstance.objects.filter(status='In Repair', piece=piece).count()
     # Equivalence management
-    try:
-        equivalences = Equivalence.objects.get(Q(pieceeq_1=piece) | Q(pieceeq_2=piece) | Q(pieceeq_3=piece)| Q(pieceeq_4=piece)
-                                       | Q(pieceeq_5=piece) | Q(pieceeq_6=piece) | Q(pieceeq_7=piece)| Q(pieceeq_8=piece)
-                                       | Q(pieceeq_9=piece) | Q(pieceeq_10=piece) | Q(pieceeq_11=piece)| Q(pieceeq_12=piece)
-                                       | Q(pieceeq_13=piece) | Q(pieceeq_14=piece) | Q(pieceeq_15=piece))
-    except:
-        equivalences = None
-    piece_eq_list = equivalences
+    equivalences = Equivalence.objects.all()
+    my_eq_list = []
+    # First we create a list of all the equivalences in which our piece is
+    for equivalence in equivalences:
+        piece_eq_list = [equivalence.pieceeq_1, equivalence.pieceeq_2, equivalence.pieceeq_3, equivalence.pieceeq_4,
+                         equivalence.pieceeq_5, equivalence.pieceeq_6, equivalence.pieceeq_7, equivalence.pieceeq_8,
+                         equivalence.pieceeq_9, equivalence.pieceeq_10, equivalence.pieceeq_11, equivalence.pieceeq_12,
+                         equivalence.pieceeq_13, equivalence.pieceeq_14, equivalence.pieceeq_15]
+        for piece_eq in piece_eq_list:
+            if piece_eq == piece:
+                for my_piece in piece_eq_list:
+                    # We make sure the equivalent piece is not our piece and not empty
+                    if my_piece is not None and my_piece != piece:
+                        my_eq_list.append(my_piece)
+    # my_eq_list contains all the pieces that are equivalent to our piece
+    # We now want to remove any duplicates therefore we are going to create a dictionary using the list items as keys.
+    # This will automatically remove any duplicates because dictionaries cannot have duplicates
+    my_eq_list = list(dict.fromkeys(my_eq_list))
     context = {'piece': piece, 'piece_instance': piece_instance, 'instance_installed': instance_installed,
                'instance_in_stock': instance_in_stock, 'instance_discarded': instance_discarded,
-               'instance_in_reparation': instance_in_reparation, 'piece_eq_list': piece_eq_list}
+               'instance_in_reparation': instance_in_reparation, 'my_eq_list': my_eq_list}
     return render(request, 'inventory/piece/piece_detail.html', context)
 
 

--- a/SIMS/inventory/views.py
+++ b/SIMS/inventory/views.py
@@ -1251,7 +1251,11 @@ class EquivalenceListView(ListView):
 
 def equivalence_detail(request, primary_key):
     equivalence = Equivalence.objects.get(pk=primary_key)
-    context = {'equivalence': equivalence}
+    pieces = [equivalence.pieceeq_1, equivalence.pieceeq_2, equivalence.pieceeq_3, equivalence.pieceeq_4,
+              equivalence.pieceeq_5, equivalence.pieceeq_6, equivalence.pieceeq_7, equivalence.pieceeq_8,
+              equivalence.pieceeq_9, equivalence.pieceeq_10, equivalence.pieceeq_11, equivalence.pieceeq_12,
+              equivalence.pieceeq_13, equivalence.pieceeq_14, equivalence.pieceeq_15]
+    context = {'equivalence': equivalence, 'pieces': pieces}
     return render(request, 'inventory/equivalence/equivalence_detail.html', context)
 
 

--- a/SIMS/templates/inventory/equivalence/equivalence_detail.html
+++ b/SIMS/templates/inventory/equivalence/equivalence_detail.html
@@ -8,24 +8,22 @@
   <div class="card-body">
     <h5 class="card-title"> Name : {{ equivalence.name }}</h5>
     <p class="card-text">
-    	<ul>
-  <p><strong>Piece equivalent:</strong></p>
-  <p><a href="{{ equivalence.pieceeq_1.get_absolute_url }}">{{  equivalence.pieceeq_1.name }}</a></p>
-	  		<p><a href="{{ equivalence.pieceeq_2.get_absolute_url }}">{{  equivalence.pieceeq_2.name }}</a></p>
-	  		<p><a href="{{ equivalence.pieceeq_3.get_absolute_url }}">{{  equivalence.pieceeq_3.name }}</a></p>
-	  		<p><a href="{{ equivalence.pieceeq_4.get_absolute_url }}">{{  equivalence.pieceeq_4.name }}</a></p>
-	  		<p><a href="{{ equivalence.pieceeq_5.get_absolute_url }}">{{  equivalence.pieceeq_5.name }}</a></p>
-	  		<p><a href="{{ equivalence.pieceeq_6.get_absolute_url }}">{{  equivalence.pieceeq_6.name }}</a></p>
-	  		<p><a href="{{ equivalence.pieceeq_7.get_absolute_url }}">{{  equivalence.pieceeq_7.name }}</a></p>
-	  		<p><a href="{{ equivalence.pieceeq_8.get_absolute_url }}">{{  equivalence.pieceeq_8.name }}</a></p>
-	  		<p><a href="{{ equivalence.pieceeq_9.get_absolute_url }}">{{  equivalence.pieceeq_9.name }}</a></p>
-	  		<p><a href="{{ equivalence.pieceeq_10.get_absolute_url }}">{{  equivalence.pieceeq_10.name }}</a></p>
-	  		<p><a href="{{ equivalence.pieceeq_11.get_absolute_url }}">{{  equivalence.pieceeq_11.name }}</a></p>
-	  		<p><a href="{{ equivalence.pieceeq_12.get_absolute_url }}">{{  equivalence.pieceeq_12.name }}</a></p>
-	  		<p><a href="{{ equivalence.pieceeq_13.get_absolute_url }}">{{  equivalence.pieceeq_13.name }}</a></p>
-	  		<p><a href="{{ equivalence.pieceeq_14.get_absolute_url }}">{{  equivalence.pieceeq_14.name }}</a></p>
-	  		<p><a href="{{ equivalence.pieceeq_15.get_absolute_url }}">{{  equivalence.pieceeq_15.name }}</a></p>
-	</ul>
+    <p><strong>Piece equivalent:</strong></p>
+	<table class="table table-light table-striped">
+    	<thead>
+        <tr>
+		<th>Name</th>
+		<th>CAE Part Number</th>
+		</tr>
+  		</thead>
+    	{% for piece in pieces %}
+		{% if piece %}
+		<tr class="datarow">
+      	<td><a href="{{ piece.get_absolute_url }}">{{ piece.name }}</a></td>
+      	<td>{{ piece.cae_part_number }}</td>
+    	{% endif %}
+    	{% endfor %}
+	</table>
   </div>
 	<td><a href="{% url 'equivalence-update' equivalence.id %}" class="btn btn-outline-secondary btn-sm">Update</a>
 </div>

--- a/SIMS/templates/inventory/piece/piece_detail.html
+++ b/SIMS/templates/inventory/piece/piece_detail.html
@@ -29,23 +29,21 @@
   {% if piece.website %}
   	<a href="{{ piece.website }}">{{ piece.website }}</a>
   {% endif %}
-  {% if piece_eq_list %}
+  {% if my_eq_list %}
 	  <p><strong>Pieces equivalent:</strong></p>
-	  		<p><a href="{{ piece_eq_list.pieceeq_1.get_absolute_url }}">{{  piece_eq_list.pieceeq_1.name }}</a></p>
-	  		<p><a href="{{ piece_eq_list.pieceeq_2.get_absolute_url }}">{{  piece_eq_list.pieceeq_2.name }}</a></p>
-	  		<p><a href="{{ piece_eq_list.pieceeq_3.get_absolute_url }}">{{  piece_eq_list.pieceeq_3.name }}</a></p>
-	  		<p><a href="{{ piece_eq_list.pieceeq_4.get_absolute_url }}">{{  piece_eq_list.pieceeq_4.name }}</a></p>
-	  		<p><a href="{{ piece_eq_list.pieceeq_5.get_absolute_url }}">{{  piece_eq_list.pieceeq_5.name }}</a></p>
-	  		<p><a href="{{ piece_eq_list.pieceeq_6.get_absolute_url }}">{{  piece_eq_list.pieceeq_6.name }}</a></p>
-	  		<p><a href="{{ piece_eq_list.pieceeq_7.get_absolute_url }}">{{  piece_eq_list.pieceeq_7.name }}</a></p>
-	  		<p><a href="{{ piece_eq_list.pieceeq_8.get_absolute_url }}">{{  piece_eq_list.pieceeq_8.name }}</a></p>
-	  		<p><a href="{{ piece_eq_list.pieceeq_9.get_absolute_url }}">{{  piece_eq_list.pieceeq_9.name }}</a></p>
-	  		<p><a href="{{ piece_eq_list.pieceeq_10.get_absolute_url }}">{{  piece_eq_list.pieceeq_10.name }}</a></p>
-	  		<p><a href="{{ piece_eq_list.pieceeq_11.get_absolute_url }}">{{  piece_eq_list.pieceeq_11.name }}</a></p>
-	  		<p><a href="{{ piece_eq_list.pieceeq_12.get_absolute_url }}">{{  piece_eq_list.pieceeq_12.name }}</a></p>
-	  		<p><a href="{{ piece_eq_list.pieceeq_13.get_absolute_url }}">{{  piece_eq_list.pieceeq_13.name }}</a></p>
-	  		<p><a href="{{ piece_eq_list.pieceeq_14.get_absolute_url }}">{{  piece_eq_list.pieceeq_14.name }}</a></p>
-	  		<p><a href="{{ piece_eq_list.pieceeq_15.get_absolute_url }}">{{  piece_eq_list.pieceeq_15.name }}</a></p>
+	    <table class="table table-light table-striped">
+    	<thead>
+        <tr>
+		<th>Name</th>
+		<th>CAE Part Number</th>
+		</tr>
+  		</thead>
+    	{% for piece in my_eq_list %}
+		<tr class="datarow">
+      	<td><a href="{{ piece.get_absolute_url }}">{{ piece.name }}</a></td>
+      	<td>{{ piece.cae_part_number }}</td>
+    	{% endfor %}
+	    </table>
   {% endif %}
   <p><strong>History:</strong></p>
 			<table class="table table-light table-striped">


### PR DESCRIPTION
1. Corrected the way equivalent pieces are displayes on piece detail page
We don't display the current piece
Strategy:
- First we create a list of all the equivalences in which our piece is
- We remove any duplicates therefore we are going to create a dictionary using the list items as key
- We use the created dictionary in the piece_detail.html page to loop through it and display each element

2. Equivalence detail page now shows name and PN of piece being part of the equivalence

3. The equivalence now must have a name to avoid avoid empty ones
