### PR TITLE
Document display

### DIFF
--- a/SIMS/templates/inventory/consumable/consumable_detail.html
+++ b/SIMS/templates/inventory/consumable/consumable_detail.html
@@ -26,7 +26,9 @@
   	      <a href="{{ consumable.website }}">{{ consumable.website }}</a>
         {% endif %}
   		<p><strong>Description: </strong> {{ consumable.description}}</p>
-        <p><strong>Documentation:</strong> <a href="{{MEDIA_URL}}{{ consumable.documentation }}">{{ consumable.documentation }}</a></p>
+  		{% if consumable.documentation %}
+  		<p><a href="{{MEDIA_URL}}{{ consumable.documentation }}"><strong>Documentation</strong> </a></p>
+  		{% endif %}
         <p><strong>Type:</strong> {{ consumable.item_type }}</p>
         <p><strong>Characteristic:</strong> {{ consumable.item_characteristic }}</p>
         {% if consumable.is_rspl %}

--- a/SIMS/templates/inventory/instances/piece_instance_detail.html
+++ b/SIMS/templates/inventory/instances/piece_instance_detail.html
@@ -19,7 +19,9 @@
 		{% else %}
 			<p><strong>Assembly: </strong> {{ kit }}</p>
 		{% endif %}
-		<p><strong>Calibration document: </strong> <a href="{{MEDIA_URL}}{{ piece_instance.calibration_document }}">{{ piece_instance.calibration_document }}</a></p>
+		{% if piece_instance.calibration_document %}
+		<p><a href="{{MEDIA_URL}}{{ piece_instance.calibration_document }}"><strong>Calibration document</strong> </a></p>
+		{% endif %}
   		<p><strong>Provider: </strong> {{ piece_instance.piece.provider }}</p>
   		<p><strong>Provider Serial Number: </strong> {{ piece_instance.piece.manufacturer }}</p>
   		<p><strong>Manufacturer: </strong> {{ piece_instance.manufacturer_serialnumber }}</p>

--- a/SIMS/templates/inventory/instances/piece_instance_list.html
+++ b/SIMS/templates/inventory/instances/piece_instance_list.html
@@ -59,7 +59,11 @@ action="{%url 'search-instance-database' %}">
       <td>{{ piece_instance.status }}</td>
       <td>{{ piece_instance.condition }}</td>
 	  <td>{{piece_instance.date_calibration}}</td>
-      <td><a href="{{MEDIA_URL}}{{ piece_instance.calibration_document }}">{{ piece_instance.calibration_document }}</a></td>
+      {% if piece_instance.calibration_document  %}
+      <td><a href="{{MEDIA_URL}}{{ piece_instance.calibration_document }}">File</a></td>
+      {% else %}
+      <td>No Documentation</td>
+      {% endif %}
 	  <td>{{piece_instance.date_end_of_life}}</td>
 	  <td>{{piece_instance.date_guarantee}}</td>
       <td>{{piece_instance.date_created}}</td>

--- a/SIMS/templates/inventory/piece/piece_detail.html
+++ b/SIMS/templates/inventory/piece/piece_detail.html
@@ -22,7 +22,9 @@
   {% if piece.is_obsolete %}
   <p><strong>Piece is obsolete</strong></p>
   {% endif %}
-  <p><strong>Documentation:</strong> <a href="{{MEDIA_URL}}{{ piece.documentation }}">{{ piece.documentation }}</a></p>
+  {% if piece.documentation %}
+  <p><a href="{{MEDIA_URL}}{{ piece.documentation }}"><strong>Documentation</strong> </a></p>
+  {% endif %}
   <p><strong>Calibration Recurrence (days):</strong> {{piece.calibration_recurrence}}</p>
   <p><strong>Type:</strong> {{ piece.item_type }}</p>
   <p><strong>Characteristic:</strong> {{ piece.item_characteristic }}</p>

--- a/SIMS/templates/inventory/piece/piece_list.html
+++ b/SIMS/templates/inventory/piece/piece_list.html
@@ -32,7 +32,11 @@ action="{%url 'search-piece-database' %}">
       <td>{{ piece.manufacturer }}</td>
       <td>{{ piece.manufacturer_part_number }}</td>
       <td>{{ piece.provider_part_number }}</td>
-      <td><a href="{{MEDIA_URL}}{{ piece.documentation }}">{{ piece.documentation }}</a></td>
+      {% if piece.documentation %}
+      <td><a href="{{MEDIA_URL}}{{ piece.documentation }}">File</a></td>
+      {% else %}
+      <td>No Documentation</td>
+      {% endif %}
       <td>{{ piece.item_type }}</td>
       <td>{{ piece.item_characteristic }}</td>
     </tr>

--- a/SIMS/templates/inventory/search/search_instance.html
+++ b/SIMS/templates/inventory/search/search_instance.html
@@ -31,7 +31,11 @@
       <td>{{ result.manufacturer_serialnumber }}</td>
       <td>{{ result.piece.provider }}</td>
       <td>{{ result.provider_serialnumber }}</td>
-      <td>{{ result.piece.documentation }}</td>
+      {% if result.piece.documentation %}
+      <td><a href="{{MEDIA_URL}}{{ result.piece.documentation }}">File</a></td>
+      {% else %}
+      <td>No Documentation</td>
+      {% endif %}
       <td>{{ result.piece.item_type }}</td>
       <td>{{ result.piece.item_characteristic }}</td>
         {% if result.eighth_location %}


### PR DESCRIPTION
Corrected links towards:
- Calibration documents (instances)
- Documentation (pieces)
The goal is to save space in the display