### PR TITLE
Various fixes

### DIFF
--- a/SIMS/inventory/models.py
+++ b/SIMS/inventory/models.py
@@ -534,7 +534,13 @@ class PieceInstance(models.Model):
         :rtype: BooleanField
         """
         calibration_is_due = False
-        if(self.next_calibration):
+        if(self.date_calibration):
+            due_days = self.date_calibration - date.today()
+            if due_days < datetime.timedelta(days=10):
+                calibration_is_due = True
+            else:
+                calibration_is_due = False
+        elif(self.next_calibration):
             due_days = self.next_calibration - date.today()
             if due_days < datetime.timedelta(days=10):
                 calibration_is_due = True

--- a/SIMS/templates/inventory/instances/piece_instance_detail.html
+++ b/SIMS/templates/inventory/instances/piece_instance_detail.html
@@ -47,7 +47,11 @@
   		<p><strong>Manufacturer: </strong> {{ piece_instance.manufacturer_serialnumber }}</p>
   		<p><strong>Manufacturer Serial Number: </strong> {{ piece_instance.manufacturer_serialnumber }}</p>
   		<p><strong>Date Created: </strong> {{ piece_instance.date_created }}</p>
-  		<p><strong>Next Calibration: </strong> {{ piece_instance.next_calibration }}</p>
+		{% if piece_instance.date_calibration %}
+  			<p><strong>Next Calibration: </strong> {{ piece_instance.date_calibration }}</p>
+		{% else %}
+  			<p><strong>Next Calibration: </strong> {{ piece_instance.next_calibration }}</p>
+		{% endif %}
   		<p><strong>End of Life: </strong> {{ piece_instance.date_end_of_life }}</p>
   		<p><strong>Time spent in reparation: </strong> {{ piece_instance.time_spent_in_r_instance }} days</p>
         <p><strong>Location: </strong>{% if piece_instance.eighth_location %}

--- a/SIMS/templates/inventory/movement/movement_detail.html
+++ b/SIMS/templates/inventory/movement/movement_detail.html
@@ -9,10 +9,10 @@
     <h5 class="card-title"> Reference Number : {{ movement.reference_number }}</h5>
     <p class="card-text">
     	<ul>
-  <p><strong>This item:</strong> {{movement.item_1}}</p>
-  <p><strong>Was replaced with this item:</strong> {{movement.item_2}}</p>
-  <p><strong>Reason for item being replaced:</strong> {{movement.update_comment_item1}}</p>
-  <p><strong>Reason for item chosen to replace:</strong> {{movement.update_comment_item2}}</p>
+  <p><strong>This instance:</strong> {{movement.item_1}}</p>
+  <p><strong>Was replaced with this instance:</strong> {{movement.item_2}}</p>
+  <p><strong>Reason for instance being replaced:</strong> {{movement.update_comment_item1}}</p>
+  <p><strong>Reason for instance chosen to replace:</strong> {{movement.update_comment_item2}}</p>
   <p><strong>Date it was done:</strong> {{movement.date_created}}</p>
 	</ul>
   </div>

--- a/SIMS/templates/inventory/movement/movement_list.html
+++ b/SIMS/templates/inventory/movement/movement_list.html
@@ -15,8 +15,8 @@
     <tr>
 	<th>Reference Number</th>
 	<th>Date</th>
-	<th>Item 1</th>
-	<th>Item 2</th>
+	<th>Removed Instance</th>
+	<th>Mounted Instance</th>
 	</tr>
   </thead>
     {% for movement in movements %}


### PR DESCRIPTION
Movement list: Instead of "Item 1" read "Removed instance" and instead of "Item 2" read "Mounted instance"
Movement detail: Instead of "item" read "Instance"
Instance calibration date management: if date is manually filled, disregard automatic calculation